### PR TITLE
fix : JavaMailSender 설정 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,gradle,java,intellij+all
 
+/src/main/resources/application-mail.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,8 +71,6 @@ spring:
           tokenUri: https://kauth.kakao.com/oauth/token
           userInfoUri: https://kapi.kakao.com/v2/user/me
           userNameAttribute: id
-  profiles:
-    include: oauth
 springdoc:
   api-docs.path: /api-docs
   swagger-ui.path: /swagger-ui.html
@@ -90,16 +88,6 @@ spring:
     properties:
       hibernate.format_sql: true
       hibernate.default_batch_fetch_size: 100
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${Email_Id}
-    password: ${Email_Pw}
-    properties:
-      mail.smtp:
-        auth: true
-        timeout: 5000
-        starttls.enable: true
   datasource:
     url: ${DB_URL}
     username: ${DB_USER}
@@ -109,6 +97,10 @@ spring:
     redis:
       host: localhost
       port: 6379
+---
+spring:
+  profiles:
+    include: mail
 springdoc:
   api-docs.path: /api-docs
   swagger-ui.path: /swagger-ui.html


### PR DESCRIPTION
### JavaMailSender 설정 분리
- 환경변수를 이용한 설정 시 어플리케이션 실행 실패
- profiles를 이용해 분리 설정